### PR TITLE
Added Windows 7 requirement (to suppress warnings...)

### DIFF
--- a/Fandro2/Properties/AssemblyInfo.cs
+++ b/Fandro2/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.6.1.0")]
 [assembly: AssemblyFileVersion("0.6.1.0")]
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]


### PR DESCRIPTION
Suppress Windows 7 specific warnings

`
This call site is reachable on all platforms. 'xyz' is only supported on: 'Windows' 7.0 and later.
`